### PR TITLE
Updating chai-as-promised to 7.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   },
   "license": "ISC",
   "devDependencies": {
-    "chai": "^4.0.0",
-    "chai-as-promised": "^6.0.0",
+    "chai": "^4.0.2",
+    "chai-as-promised": "^7.0.0",
     "coveralls": "^2.12.0",
     "cz-conventional-changelog": "^2.0.0",
     "eslint": "^3.19.0",


### PR DESCRIPTION

Please update [chai-as-promised](https://npmjs.org/package/chai-as-promised) to version 7.0.0.

If this passes your tests you can merge it in.  If not please use this branch for changes.

 * [```a60bf92```](https://github.com/domenic/chai-as-promised/commit/a60bf923d25f464a36a3d6ff4958137c397e1336) ```7.0.0```
 * [```a92de93```](https://github.com/domenic/chai-as-promised/commit/a92de93caea9803c11736a1208234d3be7d3a42c) ```Convert tests away from CoffeeScript```
 * [```ce2d4cb```](https://github.com/domenic/chai-as-promised/commit/ce2d4cb04bad5b2ea10f4bd5b74fdcc54ab89227) ```Add a note about using other Chai plugins```
 * [```e8021e4```](https://github.com/domenic/chai-as-promised/commit/e8021e44021e769e1eed4dfdd85856b365287870) ```Update for Chai v4.0```
 * [```16dde11```](https://github.com/domenic/chai-as-promised/commit/16dde11e8d566771681dd6c39fd28716c9de69fa) ```Various cleanups and updates```
 * [```0dfd211```](https://github.com/domenic/chai-as-promised/commit/0dfd21181193bb1fd46664b35893bac75df6b004) ```Test all supported versions of Chai; assume Node v&hellip;```


View the [change log](https://github.com/domenic/chai-as-promised/compare/b2cfbdc71360dad1faaa29f64bcc8ba54819084e...a60bf923d25f464a36a3d6ff4958137c397e1336).